### PR TITLE
Improve ntlm httpc request

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,3 @@
 {deps, [
-    {jsx, {git, "https://github.com/talentdeficit/jsx.git", {tag, "v2.8.0"}}}
+    {jsx, ".*", {git, "https://github.com/talentdeficit/jsx.git", {tag, "v2.8.0"}}}
 ]}.


### PR DESCRIPTION
This PR fixes two unrelated issues.

The first is a problem with some IIS server -- it looks like some of them replay to the first round of the NTLM authentication with two WWW-Authenticate headers, one specifying "NTLM" and the other "Negotiate".
As the inets HTTP client only report one authentication scheme (in my case "Negotiate") I've defined "Negotiate" as a synonym of "NTLM".
Also if the authentication scheme is unsupported, I think is preferable not to crash the process but to report the actual response and let the user of the library decide what to do.

The second problem is a bug in the dependency definition contained in `rebar.config` -- it lacks the second term of the tuple, which I set to ".*".